### PR TITLE
Keep background and fun fact on smaller window size

### DIFF
--- a/website-v3.0/src/styles/HomePage.css
+++ b/website-v3.0/src/styles/HomePage.css
@@ -127,6 +127,16 @@
 }
 
 @media (max-width: 1200px) {
+  .arrow-container {
+    transform: translateX(-4.5em);
+  }
+
+  .fun-fact {
+    transform: translateX(3em);
+  }
+}
+
+@media (max-width: 991px) {
   .background-image,
   .arrow-container,
   .fun-fact {
@@ -381,18 +391,18 @@
 }
 
 @media (max-width: 767px) {
-    .button-container {
-      flex-wrap: nowrap;
-    }
-
-    .button-red-gradiant {
-        margin-right: 20px;
-    }
-
-    .button-transparent {
-        margin-left: 20px;
-    }
+  .button-container {
+    flex-wrap: nowrap;
   }
+
+  .button-red-gradiant {
+    margin-right: 20px;
+  }
+
+  .button-transparent {
+    margin-left: 20px;
+  }
+}
 
 #statistic_num {
   font-family: "Syne";
@@ -413,7 +423,7 @@
 
 .desktop-hex {
   width: auto;
-  height:auto;
+  height: auto;
   position: absolute;
   right: -4.7%;
   top: -2%;
@@ -491,55 +501,55 @@
 }
 
 .image-container-mic-hex-popover {
-    position: relative;
-    margin-left: -11.8%;
-    margin-bottom: -1.7%;
-    z-index: 3;
+  position: relative;
+  margin-left: -11.8%;
+  margin-bottom: -1.7%;
+  z-index: 3;
 }
 
 .image-container-bow-hex-popover {
-    position: relative;
-    margin-left: -11.8%;
-    margin-bottom: -1.7%;
-    z-index: 3;
+  position: relative;
+  margin-left: -11.8%;
+  margin-bottom: -1.7%;
+  z-index: 3;
 }
 
 .image-container-headphone-hex-popover {
-    position: relative;
-    margin-left: -5.8%;
-    margin-bottom: -1.7%;
-    z-index: 3;
+  position: relative;
+  margin-left: -5.8%;
+  margin-bottom: -1.7%;
+  z-index: 3;
 }
 
 .image-container-grad-cap-hex-popover {
-    position: relative;
-    margin-left: -10.3%;
-    margin-bottom: -1.7%;
-    z-index: 3;
+  position: relative;
+  margin-left: -10.3%;
+  margin-bottom: -1.7%;
+  z-index: 3;
 }
 
 .text-popover-hex {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    color: white;
-    padding: 10px;
-    text-align: left;
-    width: 90%;
-    max-width: 400px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: white;
+  padding: 10px;
+  text-align: left;
+  width: 90%;
+  max-width: 400px;
 }
 
 .text-popover-grad-cap-hex {
-    position: absolute;
-    top: 65%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    color: white;
-    padding: 10px;
-    text-align: left;
-    width: 90%;
-    max-width: 400px;
+  position: absolute;
+  top: 65%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: white;
+  padding: 10px;
+  text-align: left;
+  width: 90%;
+  max-width: 400px;
 }
 
 @media (max-width: 1399px) {
@@ -554,7 +564,7 @@
     float: right;
     z-index: 0;
   }
-  
+
   .grad-cap-hex {
     width: auto;
     height: auto;
@@ -565,7 +575,7 @@
     float: right;
     z-index: 2;
   }
-  
+
   .mic-hex {
     width: auto;
     height: auto;
@@ -576,7 +586,7 @@
     float: right;
     z-index: 2;
   }
-  
+
   .pencil-hex {
     width: auto;
     height: auto;
@@ -587,7 +597,7 @@
     float: right;
     z-index: 2;
   }
-  
+
   .headphone-hex {
     width: auto;
     height: auto;
@@ -598,7 +608,7 @@
     float: right;
     z-index: 2;
   }
-  
+
   .bow-hex {
     width: auto;
     height: auto;
@@ -609,7 +619,7 @@
     float: right;
     z-index: 2;
   }
-  
+
   .flower-hex {
     width: auto;
     height: auto;
@@ -642,7 +652,7 @@
     float: right;
     z-index: 0;
   }
-  
+
   .grad-cap-hex {
     width: auto;
     height: auto;
@@ -653,7 +663,7 @@
     float: right;
     z-index: 2;
   }
-  
+
   .mic-hex {
     width: auto;
     height: auto;
@@ -664,7 +674,7 @@
     float: right;
     z-index: 2;
   }
-  
+
   .pencil-hex {
     width: auto;
     height: auto;
@@ -675,7 +685,7 @@
     float: right;
     z-index: 2;
   }
-  
+
   .headphone-hex {
     width: auto;
     height: auto;
@@ -686,7 +696,7 @@
     float: right;
     z-index: 2;
   }
-  
+
   .bow-hex {
     width: auto;
     height: auto;
@@ -697,7 +707,7 @@
     float: right;
     z-index: 2;
   }
-  
+
   .flower-hex {
     width: auto;
     height: auto;
@@ -722,9 +732,9 @@
     margin-left: -14.8%;
     margin-bottom: -1.7%;
     z-index: 3;
-   }
+  }
 
-   .image-container-headphone-hex-popover {
+  .image-container-headphone-hex-popover {
     position: relative;
     margin-left: -11.4%;
     margin-bottom: -1.7%;
@@ -751,7 +761,7 @@
     float: right;
     z-index: 0;
   }
-  
+
   .grad-cap-hex {
     width: auto;
     height: auto;
@@ -762,7 +772,7 @@
     float: right;
     z-index: 2;
   }
-  
+
   .mic-hex {
     width: auto;
     height: auto;
@@ -773,7 +783,7 @@
     float: right;
     z-index: 2;
   }
-  
+
   .pencil-hex {
     width: auto;
     height: auto;
@@ -784,7 +794,7 @@
     float: right;
     z-index: 2;
   }
-  
+
   .headphone-hex {
     width: auto;
     height: auto;
@@ -795,7 +805,7 @@
     float: right;
     z-index: 2;
   }
-  
+
   .bow-hex {
     width: auto;
     height: auto;
@@ -806,7 +816,7 @@
     float: right;
     z-index: 2;
   }
-  
+
   .flower-hex {
     width: auto;
     height: auto;
@@ -867,23 +877,23 @@
   .grad-cap-hex {
     display: none;
   }
-  
+
   .mic-hex {
     display: none;
   }
-  
+
   .pencil-hex {
     display: none;
   }
-  
+
   .headphone-hex {
     display: none;
   }
-  
+
   .bow-hex {
     display: none;
   }
-  
+
   .flower-hex {
     display: none;
   }


### PR DESCRIPTION
# Sprint 2 + What We Do Cards 2

## Description
Display uwpm background and fun fact on smaller window size

## Details
Modified media queries

## Type of change
- [#] Bug fix 
- [ ] New feature 
- [ ] Existing feature

## Screenshots
<img width="999" alt="Screenshot 2023-07-15 at 11 06 21 PM" src="https://github.com/UWPM/website-v3.0/assets/71087545/87249d6e-de85-4842-8dfb-920980771982">


## Testing
Confirmed that background and fun fact display on smaller window size

## Checklist:

- [# ] My code follows the style guidelines of this project
- [ #] I have performed a self-review of my code
- [# ] I have commented my code, particularly in hard-to-understand areas
- [# ] My code passes all builds and tests


