### PR TITLE
Company Logos Overlapping Fix

### DIFF
--- a/src/components/WorkedAt.js
+++ b/src/components/WorkedAt.js
@@ -40,7 +40,7 @@ export default function WorkedAt({ show }) {
           <Col xs={6} md={2} className="company-image pb-4"><img height={30} src={Datadog} alt={"Datadog"} /></Col>
           <Col xs={6} md={2} className="company-image pb-4"><img height={50} src={AmericanExpress} alt={"AmericanExpress"} /></Col>
           <Col xs={6} md={2} className="company-image pb-4"><img height={30} src={Shopify} alt={"Shopify"} /></Col>
-          <Col xs={6} md={2} className="company-image pb-4"><img height={30} src={Autodesk} alt={"Autodesk"} /></Col>
+          <Col xs={6} md={2} className="company-image pb-4"><img height={30} width={"100%"} src={Autodesk} alt={"Autodesk"} /></Col>
         </Row>
         <div className="spacer"></div>
       </Container>


### PR DESCRIPTION
# Sprint 1: Company Logos Overlapping

## Description
At around 900px, the company logos overlap. We want to avoid overlapping at all breakpoints.

## Details
Autodesk logo was the culprit of having a really long length, so I manually set a percentage width on it making the view fit more.

## Type of Change
Bug fix 

## Screenshots
<img width="807" alt="image" src="https://github.com/UWPM/website-v3.0/assets/28720612/3e0bd49f-61bf-495c-8876-da44ffc752a6">


## Testing
Ran manual testing on different resolutions and it works on my end.

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My code passes all builds and tests