### PR TITLE
Past Events - Mobile Improvements

### DIFF
--- a/src/components/PastEvents.js
+++ b/src/components/PastEvents.js
@@ -16,6 +16,7 @@ export default function PastEvents() {
     setIsMobile(window.innerWidth < 768);
   };
 
+  // Event listener for dynamic width changing
   useEffect(() => {
     window.addEventListener('resize', handleResize);
 
@@ -24,6 +25,7 @@ export default function PastEvents() {
     };
   }, []);
 
+  // Array of [imageUrl, instagramUrl]
   const flatImages = [
     [speakerSneakPeak, 'https://www.instagram.com/p/CuinX2tANsc/'],
     [blueprintUWPM, 'https://www.instagram.com/p/CuVlp-SJFqk/'],
@@ -33,6 +35,7 @@ export default function PastEvents() {
     [fall22Prodcon, 'https://www.instagram.com/p/CjycXW0gcyo/'],
   ];
 
+  // Change number of rows dynamically
   const getCols = (data) => {
     const colsPerRow = isMobile ? 2 : 3;
     const rows = [];


### PR DESCRIPTION
# Sprint 3 Past Events (Mobile)

## Description
Update past events for mobile such that we render 2 items a row

## Details
Used dynamic code to change the number of rows.

## Type of Change
Existing Feature

## Screenshots
For mobile it fits 2 events per row, instead of the 3 as in desktop. Should be more readable than before, but please let me know if it can be bigger or we want to do 
<img width="389" alt="image" src="https://github.com/UWPM/website-v3.0/assets/28720612/02e8c387-6505-4674-ad3e-87b4b37354ee">


## Testing
Ran in multiple views and mobile views

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X ] My code passes all builds and tests